### PR TITLE
CRUD DynamoDB policy to ProcessChannel

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -156,7 +156,7 @@ Resources:
       CodeUri: lambdas/process-channel
       Timeout: 60
       Policies:
-        - DynamoDBReadPolicy:
+        - DynamoDBCrudPolicy:
             TableName: !Ref ItemsTable
         - SQSPollerPolicy:
             QueueName: !GetAtt ChannelQueue.QueueName


### PR DESCRIPTION
Previously:
```
botocore.exceptions.ClientError: An error occurred (AccessDeniedException) when calling the BatchWriteItem operation
```